### PR TITLE
Substraction of frames_count over 24h while calculation SMPTE is corrupted

### DIFF
--- a/lib/timecode.js
+++ b/lib/timecode.js
@@ -79,7 +79,7 @@ var Timecode = {
 			this.hours = frame_count / (3600 * this.int_framerate);
 			if (this.hours > 23) {
 				this.hours = this.hours % 24;
-				frame_count = frame_count - (24 * 3600 * self.int_framerate);
+				frame_count = frame_count - (23 * 3600 * this.int_framerate);
 			}
 			this.minutes = (frame_count % (3600 * this.int_framerate)) / (60 * this.int_framerate);
 			this.seconds = ((frame_count % (3600 * this.int_framerate)) % (60 * this.int_framerate)) / this.int_framerate;


### PR DESCRIPTION
So I came along this frame_count _1412630992027_ while framerate is _25_. 
This should result in a SMPTE similiar to _23:29:52:00_.
But I got this: _23:NaN:NaN:NaN_

After looking into the function, I discovered an interessting bug (or two).
I fixed them and both.
