### PR TITLE
Resolves issue: Dropframe isn't accurate #4.var frames_per_minute cal wa...

### DIFF
--- a/lib/timecode.js
+++ b/lib/timecode.js
@@ -162,7 +162,7 @@ var Timecode = {
 			frames_per_hour = Math.round(framerate * 60 * 60),
 			frames_per_24_hours = frames_per_hour * 24,
 			frames_per_10_minutes = Math.round(framerate * 60 * 10),
-			frames_per_minute = Math.round(framerate * 60) - drop_frames;
+			frames_per_minute = Math.round(framerate * 60);
 		// Roll over clock if greater than 24 hours
 		frame_number = frame_number % frames_per_24_hours;
 		// If time is negative, count back from 24 hours


### PR DESCRIPTION
This update corrects the frameNumberToDropFrameTimecode calculation. Only tested with 29.97 fps
var tcUpdated = Timecode.init({framerate:29.97002997002997, timecode: '00:00:59:29', drop_frame: true});

tcUpdated.toString()
"00:00:59;29"

tcUpdated.add('00:00:00:01')
tcUpdated.toString()
"00:01:00;02"

tcUpdated.subtract('00:00:00:01')
tcUpdated.toString()
"00:00:59;29"

tcUpdated.subtract('00:00:00:01')
tcUpdated.toString()
"00:00:59;28"